### PR TITLE
Add "keep" transform and update rust edition to 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,27 +13,12 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -49,15 +34,6 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-parse"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
@@ -67,18 +43,18 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -87,9 +63,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "clap"
@@ -117,7 +99,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -125,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.1"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406e68b4de5c59cfb8f750a7cbd4d31ae153788b8352167c1e5f4fc26e8c91e9"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -152,26 +134,58 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "dbus"
-version = "0.9.7"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
  "libc",
  "libdbus-sys",
- "winapi",
+ "windows-sys",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -179,15 +193,25 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
- "anstream 0.6.20",
+ "anstream",
  "anstyle",
  "env_filter",
  "jiff",
  "log",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -198,7 +222,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iio-niri"
-version = "2.1.0"
+version = "2.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -216,22 +240,23 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -241,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -252,30 +277,30 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "niri-ipc"
@@ -290,29 +315,51 @@ dependencies = [
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -326,18 +373,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -347,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -358,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "serde"
@@ -394,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -407,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -417,10 +464,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -432,9 +480,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -442,10 +490,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.18"
+name = "thiserror"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -454,106 +522,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iio-niri"
-version = "2.2.0"
-edition = "2021"
+version = "2.3.0"
+edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ Then start IIO-Niri in `listen` mode with Niri:
 spawn-at-startup "iio-niri" "listen" "--monitor" "eDP-1"
 ```
 
+You can also remap the orientation you want your screen to have based on what the sensor detects by passing `--transform <normal> <left-up> <bottom-up> <right-up>`. Possible values include `normal` (0°), `90` `180` `270` and `keep` (keeps whatever was previously used). A common usecase is disabling portrait orientations: `--transform normal keep 180 keep`
+
 ### Communicating with a running instance of IIO-Niri
 
 IIO-Niri generates its own socket for Inter Process Communication (IPC). You can use the `msg` sub-command to send requests to the IPC.

--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use dbus::{
-    blocking::{stdintf::org_freedesktop_dbus::Properties, Connection, Proxy},
-    message::MatchRule,
     Message,
+    blocking::{Connection, Proxy, stdintf::org_freedesktop_dbus::Properties},
+    message::MatchRule,
 };
 use log::debug;
 use std::time::Duration;
@@ -20,19 +20,18 @@ impl Accelerometer {
     /// Create the DBus connection to the Accelerometer
     fn create_dbus_connection() -> Result<Connection> {
         debug!("Connecting to the system bus...");
-        let conn = match Connection::new_system() {
-            Ok(it) => it,
-            Err(_) => return Err(anyhow!("Couldn't open a connection to the system bus.")),
+        let Ok(conn) = Connection::new_system() else {
+            return Err(anyhow!("Couldn't open a connection to the system bus."));
         };
         debug!("Connected to the system bus.");
 
         debug!("Setting matches for iio-sensor-proxy...");
         conn.add_match_no_cb("type='signal',interface='org.freedesktop.DBus.Properties'")?;
-        conn.add_match_no_cb(format!("type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged',arg0='{}'", INTERFACE).as_str())?;
+        conn.add_match_no_cb(format!("type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',member='NameOwnerChanged',arg0='{INTERFACE}'").as_str())?;
 
         conn.add_match(
             MatchRule::new_signal("org.freedesktop.DBus", "PropertiesChanged"),
-            |_: (), _: &Connection, _: &Message| true,
+            |(): (), _: &Connection, _: &Message| true,
         )?;
         debug!("Finished setting matches for iio-sensor-proxy.");
 
@@ -55,7 +54,7 @@ impl Accelerometer {
     }
 
     /// Creates the DBus proxy to query and manage the Accelerometer.
-    pub fn proxy<'a>(&'a self) -> Proxy<'a, &'a Connection> {
+    pub fn proxy(&self) -> Proxy<'_, &Connection> {
         Proxy::new(INTERFACE, PATH, self.timeout, &self.dbus_connection)
     }
 
@@ -83,7 +82,7 @@ impl Accelerometer {
                 .method_call(INTERFACE, "ReleaseAccelerometer", ());
 
         match result {
-            Ok(_) => {
+            Ok(()) => {
                 debug!("Accelerometer released.");
                 Ok(())
             }
@@ -99,7 +98,7 @@ impl Accelerometer {
                 .method_call(INTERFACE, "ClaimAccelerometer", ());
 
         match result {
-            Ok(_) => {
+            Ok(()) => {
                 debug!("Accelerometer claimed.");
                 Ok(())
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,8 +1,7 @@
+use crate::state::TransformAction;
 use clap::{ArgAction, Args, Command, Parser, Subcommand};
 use clap_complete::{generate, Generator, Shell};
 use clap_verbosity_flag::{Verbosity, WarnLevel};
-
-use crate::state::TransformAction;
 
 /// Print the completion of the given command to the given shell on stdout.
 pub fn print_completions<G: Generator>(generator: G, cmd: &mut Command) {
@@ -58,7 +57,7 @@ pub struct ListenArgs {
     ///
     /// In some devices the accelerometer orientation doesn't match the display orientation.
     /// This option allows you to provide the mapping from your accelerometer orientation to Niri's transform
-    /// Passing a value such as 90,normal,180,270 will provide the following accelerometer mapping:
+    /// Passing a value such as `90 normal 180 270` will provide the following accelerometer mapping:
     ///
     /// - normal -> 90
     /// - left-up -> normal
@@ -66,13 +65,7 @@ pub struct ListenArgs {
     /// - right-up -> 270
     ///
     /// Additionally, the special value "keep" can be used to keep the previous orientation.
-    #[clap(
-        short = 'd',
-        long,
-        value_delimiter = ',',
-        num_args = 4,
-        verbatim_doc_comment
-    )]
+    #[clap(short = 'd', long, num_args = 4, verbatim_doc_comment)]
     pub transform: Option<Vec<TransformAction>>,
 
     /// The number of milliseconds before timeout for a dbus request
@@ -180,7 +173,7 @@ pub struct ChangeTransformArgs {
     ///
     /// In some devices the accelerometer orientation doesn't match the display orientation
     /// This option allows you to provide the mapping from your accelerometer orientation to Niri's transform
-    /// Passing a value such as 90,normal,180,270 will provide the following accelerometer mapping:
+    /// Passing a value such as `90 normal 180 270` will provide the following accelerometer mapping:
     ///
     /// - normal -> 90
     /// - left-up -> normal

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,8 @@
 use clap::{ArgAction, Args, Command, Parser, Subcommand};
 use clap_complete::{generate, Generator, Shell};
 use clap_verbosity_flag::{Verbosity, WarnLevel};
-use niri_ipc::Transform;
+
+use crate::state::TransformAction;
 
 /// Print the completion of the given command to the given shell on stdout.
 pub fn print_completions<G: Generator>(generator: G, cmd: &mut Command) {
@@ -63,6 +64,8 @@ pub struct ListenArgs {
     /// - left-up -> normal
     /// - bottom-up -> 180
     /// - right-up -> 270
+    ///
+    /// Additionally, the special value "keep" can be used to keep the previous orientation.
     #[clap(
         short = 'd',
         long,
@@ -70,7 +73,7 @@ pub struct ListenArgs {
         num_args = 4,
         verbatim_doc_comment
     )]
-    pub transform: Option<Vec<Transform>>,
+    pub transform: Option<Vec<TransformAction>>,
 
     /// The number of milliseconds before timeout for a dbus request
     #[arg(short = 't', long = "timeout", default_value_t = 5000)]
@@ -183,6 +186,8 @@ pub struct ChangeTransformArgs {
     /// - left-up -> normal
     /// - bottom-up -> 180
     /// - right-up -> 270
+    ///
+    /// Additionally, the special value "keep" can be used to keep the previous orientation.
     #[clap(num_args = 4, verbatim_doc_comment)]
-    pub transform: Vec<Transform>,
+    pub transform: Vec<TransformAction>,
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,3 +1,11 @@
+use crate::{
+    app::{MsgArgs, MsgSubcommandArgs},
+    state::{State, TransformMapping},
+};
+use anyhow::{anyhow, Result};
+use log::{debug, error};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
 use std::{
     fs,
     io::{BufRead, BufReader, BufWriter, Write},
@@ -9,22 +17,12 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, Result};
-use log::{debug, error};
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-
-use crate::{
-    app::{MsgArgs, MsgSubcommandArgs},
-    state::{State, TransformMapping},
-};
-
 /// Returns the IIO-Niri socket default directory
 fn get_iio_niri_default_socket_directory() -> String {
     match std::env::var("XDG_RUNTIME_DIR") {
         Ok(val) => val,
         Err(e) => {
-            error!("Couldn't get XDG_RUNTIME_DIR:\n{}", e);
+            error!("Couldn't get XDG_RUNTIME_DIR:\n{e}");
             String::from("/tmp")
         }
     }
@@ -39,7 +37,7 @@ pub fn get_iio_niri_socket_path() -> String {
         match wayland_display {
             Ok(val) => val,
             Err(e) => {
-                error!("Couldn't get WAYLAND_DISPLAY:\n{}", e);
+                error!("Couldn't get WAYLAND_DISPLAY:\n{e}");
                 String::from("unknown")
             }
         }
@@ -100,23 +98,18 @@ impl IpcAction {
             return Err(anyhow!("The IpcAction JSON is malformed."));
         }
 
-        let action = match json.get("action") {
-            Some(v) => v,
-            None => {
-                return Err(anyhow!(
-                    "The IpcAction JSON doesn't contain a field `action`"
-                ))
-            }
+        let Some(action) = json.get("action") else {
+            return Err(anyhow!(
+                "The IpcAction JSON doesn't contain a field `action`"
+            ));
         };
 
-        let action = match action.as_str() {
-            Some(s) => s,
-            None => return Err(anyhow!("The `action` field is not a String.")),
+        let Some(action) = action.as_str() else {
+            return Err(anyhow!("The `action` field is not a String."));
         };
 
-        let value = match json.get("arg") {
-            Some(v) => v,
-            None => return Err(anyhow!("The IpcAction JSON doesn't contain a field `arg`")),
+        let Some(value) = json.get("arg") else {
+            return Err(anyhow!("The IpcAction JSON doesn't contain a field `arg`"));
         };
 
         match action {
@@ -136,7 +129,12 @@ impl IpcAction {
             "change_transform" => {
                 let mapping = match serde_json::from_value::<TransformMapping>(value.to_owned()) {
                     Ok(m) => m,
-                    Err(e) => return Err(anyhow!("The `arg` for an action of type `change_transform` couldn't be serialized into a TransformMapping:\n{}", e))
+                    Err(e) => {
+                        return Err(anyhow!(
+                            "The `arg` for an action of type `change_transform` couldn't be serialized into a TransformMapping:\n{}",
+                            e
+                        ));
+                    }
                 };
                 Ok(IpcAction::ChangeTransform(mapping))
             }
@@ -154,10 +152,12 @@ impl IpcAction {
                 "action": self.action_string(),
                 "arg": r
             }),
-            Self::ToggleLockRotation() => json!({
-                "action": self.action_string(),
-                "arg": null,
-            }),
+            Self::ToggleLockRotation() | Self::Ping() | Self::Stop() | Self::PrintState() => {
+                json!({
+                    "action": self.action_string(),
+                    "arg": null,
+                })
+            }
             Self::ChangeMonitor(monitor) => json!({
                 "action": self.action_string(),
                 "arg": monitor
@@ -165,18 +165,6 @@ impl IpcAction {
             Self::ChangeTransform(transform) => json!({
                 "action": self.action_string(),
                 "arg": transform
-            }),
-            Self::Ping() => json!({
-                "action": self.action_string(),
-                "arg": null
-            }),
-            Self::Stop() => json!({
-                "action": self.action_string(),
-                "arg": null
-            }),
-            Self::PrintState() => json!({
-                "action": self.action_string(),
-                "arg": null
             }),
         }
     }
@@ -227,15 +215,12 @@ impl Socket {
         let mut client = Client::bind_to_stream(stream)?;
         debug!("Reading request from client...");
         let request = client.receive()?;
-        debug!("Request read: {}", request);
+        debug!("Request read: {request}");
 
-        let mut state = match state.lock() {
-            Ok(s) => s,
-            Err(_) => {
-                return Err(anyhow!(
-                    "Couldn't lock on state because the value is poisonned."
-                ))
-            }
+        let Ok(mut state) = state.lock() else {
+            return Err(anyhow!(
+                "Couldn't lock on state because the value is poisonned."
+            ));
         };
 
         debug!("Parsing request as JSON...");
@@ -253,7 +238,7 @@ impl Socket {
                 Err(e) => return Err(anyhow!("Couldn't parse the response to send: {}", e)),
             },
         };
-        debug!("Response constructed: {}", response);
+        debug!("Response constructed: {response}");
         client.send(response)
     }
 
@@ -267,10 +252,7 @@ impl Socket {
             IpcAction::LockRotation(b) => {
                 let old = state.lock_rotation;
                 state.lock_rotation = b;
-                debug!(
-                    "Changing `state.lock_rotation`. Old value: `{}`, New value: `{}`",
-                    old, b
-                );
+                debug!("Changing `state.lock_rotation`. Old value: `{old}`, New value: `{b}`");
                 let response = match serde_json::to_string(&Response::new_ok(old)) {
                     Ok(s) => s,
                     Err(e) => return Err(anyhow!("Couldn't parse response to the client: {}", e)),
@@ -292,11 +274,8 @@ impl Socket {
             }
             IpcAction::ChangeMonitor(monitor) => {
                 let old = state.monitor.clone();
-                state.monitor = monitor.clone();
-                debug!(
-                    "Changing `state.monitor`. Old value: `{}`, New value: `{}`",
-                    old, monitor
-                );
+                state.monitor.clone_from(&monitor);
+                debug!("Changing `state.monitor`. Old value: `{old}`, New value: `{monitor}`");
                 let response = match serde_json::to_string(&Response::new(String::from("ok"), old))
                 {
                     Ok(s) => s,
@@ -306,11 +285,8 @@ impl Socket {
             }
             IpcAction::ChangeTransform(mapping) => {
                 let old = state.mapping.clone();
-                state.mapping = mapping.clone();
-                debug!(
-                    "Changing `state.mapping`. Old value: `{}`, New value: `{}`",
-                    old, mapping
-                );
+                state.mapping.clone_from(&mapping);
+                debug!("Changing `state.mapping`. Old value: `{old}`, New value: `{mapping}`");
                 let response = match serde_json::to_string(&Response::new_ok(old)) {
                     Ok(s) => s,
                     Err(e) => return Err(anyhow!("Couldn't parse response to the client: {}", e)),
@@ -332,7 +308,7 @@ impl Socket {
                     match serde_json::to_string(&Response::new_ok(String::from("Stopping!"))) {
                         Ok(s) => s,
                         Err(e) => {
-                            return Err(anyhow!("Couldn't parse response to the client: {}", e))
+                            return Err(anyhow!("Couldn't parse response to the client: {}", e));
                         }
                     };
                 Ok(response)
@@ -358,20 +334,20 @@ impl Socket {
             match self.socket.accept() {
                 Ok((mut stream, _)) => {
                     if let Err(e) = stream.set_read_timeout(Some(timeout)) {
-                        error!("Couldn't set read timeout on stream:\n{}", e);
-                    };
+                        error!("Couldn't set read timeout on stream:\n{e}");
+                    }
                     if let Err(e) = stream.set_write_timeout(Some(timeout)) {
-                        error!("Couldn't set write timeout on stream:\n{}", e);
-                    };
+                        error!("Couldn't set write timeout on stream:\n{e}");
+                    }
                     if let Err(e) = Self::handle_client(
                         &mut stream,
                         Arc::clone(&state),
                         Arc::clone(&should_stop),
                     ) {
-                        error!("{}", e);
+                        error!("{e}");
                     }
                 }
-                Err(err) => error!("Couldn't connect to incoming stream:\n{}", err),
+                Err(err) => error!("Couldn't connect to incoming stream:\n{err}"),
             }
         }
     }
@@ -422,11 +398,11 @@ impl Client {
 
         if let Err(e) = connection.set_read_timeout(Some(timeout)) {
             return Err(anyhow!("Couldn't set read timeout on stream:\n{}", e));
-        };
+        }
 
         if let Err(e) = connection.set_write_timeout(Some(timeout)) {
             return Err(anyhow!("Couldn't set write timeout on stream:\n{}", e));
-        };
+        }
 
         let buffers = Self::create_buffers(&connection)?;
         Ok(Self {
@@ -446,11 +422,11 @@ impl Client {
 
     /// Send a message to the client's destination
     pub fn send(&mut self, message: String) -> Result<()> {
-        if let Err(e) = self.writer.write_all(format!("{}\n", message).as_bytes()) {
+        if let Err(e) = self.writer.write_all(format!("{message}\n").as_bytes()) {
             return Err(anyhow!("Couldn't write message to the stream:\n{}", e));
         }
         match self.writer.flush() {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
             Err(e) => Err(anyhow!("Couldn't flush buffer:\n{}", e)),
         }
     }
@@ -473,7 +449,7 @@ impl Client {
 
         if let Err(e) = self.writer.flush() {
             return Err(anyhow!("Couldn't flush buffer:\n{}", e));
-        };
+        }
 
         self.receive()
     }
@@ -499,7 +475,7 @@ impl Client {
             MsgSubcommandArgs::Stop(_) => self.send_ipc_request(IpcAction::Stop()),
             MsgSubcommandArgs::PrintState(_) => self.send_ipc_request(IpcAction::PrintState()),
         })?;
-        println!("{}", response);
+        println!("{response}");
         Ok(())
     }
 }

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -1,18 +1,16 @@
-use anyhow::{Result, anyhow};
+use crate::{app, ipc, orientation, state};
+use anyhow::{anyhow, Result};
 use log::{debug, error, info, warn};
+use signal_hook::iterator::Signals;
+use signal_hook::{consts::TERM_SIGNALS, iterator::Handle};
 use std::{
     sync::{
-        Arc, Mutex,
         atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
     },
     thread::{self, JoinHandle},
     time::Duration,
 };
-
-use signal_hook::iterator::Signals;
-use signal_hook::{consts::TERM_SIGNALS, iterator::Handle};
-
-use crate::{app, ipc, orientation, state};
 
 /// Run the listen subcommand
 pub fn run(
@@ -21,15 +19,12 @@ pub fn run(
     socket_timeout: u64,
 ) -> Result<()> {
     debug!("Binding Niri socket...");
-    let mut niri_socket = match &args.niri_socket {
-        Some(path) => {
-            info!("Using Niri socket at {}.", path);
-            ipc::NiriSocket::connect_to(path)?
-        }
-        None => {
-            warn!("Using default Niri socket.");
-            ipc::NiriSocket::connect()?
-        }
+    let mut niri_socket = if let Some(path) = &args.niri_socket {
+        info!("Using Niri socket at {path}.");
+        ipc::NiriSocket::connect_to(path)?
+    } else {
+        warn!("Using default Niri socket.");
+        ipc::NiriSocket::connect()?
     };
     debug!("Niri socket bound!");
 
@@ -123,7 +118,7 @@ fn handle_ipc(
         iio_niri_socket.process(Arc::clone(&state), Arc::clone(&should_stop), socket_timeout);
         signals_handle.close();
         if let Err(e) = iio_niri_socket.destroy_socket() {
-            error!("{}", e);
+            error!("{e}");
         }
     })
 }
@@ -164,9 +159,9 @@ fn handle_orientation(
             niri_socket,
             Arc::clone(&should_stop),
         ) {
-            error!("{}", e);
+            error!("{e}");
             should_stop.store(true, Ordering::Relaxed);
-        };
+        }
         signals_handle.close();
     })
 }

--- a/src/listen.rs
+++ b/src/listen.rs
@@ -1,9 +1,9 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use log::{debug, error, info, warn};
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
     thread::{self, JoinHandle},
     time::Duration,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,8 @@
-use std::time::Duration;
-
+use crate::app::print_completions;
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use log::{error, info};
-
-use crate::app::print_completions;
+use std::time::Duration;
 
 mod accelerometer;
 mod app;
@@ -40,7 +38,7 @@ fn main() -> Result<()> {
     match response {
         Ok(()) => Ok(()),
         Err(e) => {
-            error!("{}", e);
+            error!("{e}");
             Err(e)
         }
     }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use anyhow::{anyhow, Result};
 use niri_ipc::{socket::Socket, Output, Request, Response};
+use std::collections::HashMap;
 
 /// Returns the monitors Niri sees.
 pub fn get_monitors(socket: &mut Socket) -> Result<HashMap<String, Output>> {
@@ -25,7 +24,7 @@ pub fn get_monitor(socket: &mut Socket, monitor_name: Option<String>) -> Result<
             if !outputs.keys().any(|key| *key == mon) {
                 return Err(anyhow!("The provided monitor ({}) is not connected.", mon));
             }
-            Ok(mon.to_owned())
+            Ok(mon.clone())
         }
         None => match outputs.keys().next() {
             Some(str) => Ok(str.to_owned()),

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -1,17 +1,14 @@
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-};
-
-use anyhow::{anyhow, Result};
-use log::{debug, info};
-
-use niri_ipc::{socket::Socket, LogicalOutput, Output, OutputAction, Request};
-
 use crate::{
     accelerometer::Accelerometer,
     monitor,
     state::{State, TransformMapping},
+};
+use anyhow::{anyhow, Result};
+use log::{debug, info};
+use niri_ipc::{socket::Socket, LogicalOutput, Output, OutputAction, Request};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, Mutex,
 };
 
 /// Update the given monitor's orientation using the accelerometer orientation.
@@ -41,11 +38,8 @@ fn update_orientation(
                         },
                     })? {
                         return Err(anyhow!(str));
-                    };
-                    info!(
-                        "Updated orientation from {:?} to {:?}.",
-                        old_orientation, orientation
-                    );
+                    }
+                    info!("Updated orientation from {old_orientation:?} to {orientation:?}.");
                     Ok(())
                 }
                 Some(Output { logical: None, .. }) => Err(anyhow!(
@@ -86,13 +80,10 @@ pub fn change_orientation_routine(
             let orientation = accelerometer.get_orientation()?;
             debug!("Orientation obtained.");
 
-            let state = match state.lock() {
-                Ok(s) => s,
-                Err(_) => {
-                    return Err(anyhow!(
-                        "Couldn't lock on state because the data is poisonned."
-                    ));
-                }
+            let Ok(state) = state.lock() else {
+                return Err(anyhow!(
+                    "Couldn't lock on state because the data is poisonned."
+                ));
             };
 
             if !state.lock_rotation {

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use anyhow::{anyhow, Result};
 use log::{debug, info};
 
-use niri_ipc::{socket::Socket, OutputAction, Request};
+use niri_ipc::{socket::Socket, LogicalOutput, Output, OutputAction, Request};
 
 use crate::{
     accelerometer::Accelerometer,
@@ -21,48 +21,45 @@ fn update_orientation(
     acc_orientation: &str,
     matrix: &TransformMapping,
 ) -> Result<()> {
-    let orientation = matrix.parse_orientation(acc_orientation);
-
-    let outputs = monitor::get_monitors(socket)?;
-
-    let old_orientation = match outputs.get(monitor) {
-        Some(output) => {
-            if let Some(logical) = output.logical {
-                logical.transform
-            } else {
-                return Err(anyhow!(
+    match matrix.parse_orientation(acc_orientation) {
+        crate::state::TransformAction::KeepPrevious => Ok(()),
+        crate::state::TransformAction::Set(orientation) => {
+            match monitor::get_monitors(socket)?.get(monitor) {
+                Some(&Output {
+                    logical:
+                        Some(LogicalOutput {
+                            transform: old_orientation,
+                            ..
+                        }),
+                    ..
+                }) if old_orientation != orientation => {
+                    debug!("Updating screen orientation...");
+                    if let Err(str) = socket.send(Request::Output {
+                        output: monitor.to_owned(),
+                        action: OutputAction::Transform {
+                            transform: orientation,
+                        },
+                    })? {
+                        return Err(anyhow!(str));
+                    };
+                    info!(
+                        "Updated orientation from {:?} to {:?}.",
+                        old_orientation, orientation
+                    );
+                    Ok(())
+                }
+                Some(Output { logical: None, .. }) => Err(anyhow!(
                     "Couldn't get the logical output information from the provided monitor ({}).",
                     monitor
-                ));
+                )),
+                None => Err(anyhow!(
+                    "Couldn't find the provided monitor ({}) in the list of outputs.",
+                    monitor
+                )),
+                _ => Ok(()),
             }
         }
-        None => {
-            return Err(anyhow!(
-                "Couldn't find the provided monitor ({}) in the list of outputs.",
-                monitor
-            ));
-        }
-    };
-
-    if old_orientation == orientation {
-        return Ok(());
     }
-
-    debug!("Updating screen orientation...");
-    if let Err(str) = socket.send(Request::Output {
-        output: monitor.to_owned(),
-        action: OutputAction::Transform {
-            transform: orientation,
-        },
-    })? {
-        return Err(anyhow!(str));
-    };
-    info!(
-        "Updated orientation from {:?} to {:?}.",
-        old_orientation, orientation
-    );
-
-    Ok(())
 }
 
 /// Defines the thread routine to listen to orientation changes.

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,12 +1,43 @@
 use std::fmt::Display;
 
 use anyhow::{anyhow, Result};
+use clap::builder::PossibleValue;
 use log::{info, warn};
 use niri_ipc::{socket::Socket, Transform};
 use serde::{Deserialize, Serialize};
 
 use crate::{app::ListenArgs, monitor};
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransformAction {
+    Set(Transform),
+    KeepPrevious,
+}
+impl clap::ValueEnum for TransformAction {
+    fn value_variants<'a>() -> &'a [Self] {
+        // sadly, clap doesnt nicely support nested ValueEnum, exactly because of this
+        // they at some point decided on returning a fixed length slice which means
+        // its not possible to just call Transform::value_variants here...
+        &[
+            Self::Set(Transform::Normal),
+            Self::Set(Transform::_90),
+            Self::Set(Transform::_180),
+            Self::Set(Transform::_270),
+            Self::Set(Transform::Flipped),
+            Self::Set(Transform::Flipped90),
+            Self::Set(Transform::Flipped180),
+            Self::Set(Transform::Flipped270),
+            Self::KeepPrevious,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<clap::builder::PossibleValue> {
+        match self {
+            TransformAction::Set(transform) => transform.to_possible_value(),
+            TransformAction::KeepPrevious => Some(PossibleValue::new("keep")),
+        }
+    }
+}
 /// Maps the accelerometer transforms (normal,left-up,bottom-up,right-up) to Niri's transforms.
 ///
 /// In some devices the accelerometer orientation doesn't match the display orientation.
@@ -19,14 +50,14 @@ use crate::{app::ListenArgs, monitor};
 /// - right-up -> 270
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransformMapping {
-    pub normal: Transform,
-    pub left_up: Transform,
-    pub bottom_up: Transform,
-    pub right_up: Transform,
+    pub normal: TransformAction,
+    pub left_up: TransformAction,
+    pub bottom_up: TransformAction,
+    pub right_up: TransformAction,
 }
 impl TransformMapping {
     /// Creates a mapping using a 4-transforms array.
-    pub fn from_transform_vec(transform: Option<Vec<Transform>>) -> Result<TransformMapping> {
+    pub fn from_transform_vec(transform: Option<Vec<TransformAction>>) -> Result<TransformMapping> {
         match transform {
             Some(vec) => {
                 if vec.len() != 4 {
@@ -43,16 +74,16 @@ impl TransformMapping {
                 }
             }
             None => Ok(TransformMapping {
-                normal: Transform::Normal,
-                left_up: Transform::_90,
-                bottom_up: Transform::_180,
-                right_up: Transform::_270,
+                normal: TransformAction::Set(Transform::Normal),
+                left_up: TransformAction::Set(Transform::_90),
+                bottom_up: TransformAction::Set(Transform::_180),
+                right_up: TransformAction::Set(Transform::_270),
             }),
         }
     }
 
     /// Parse the given accelerometer to its own Transform
-    pub fn parse_orientation(&self, orientation: &str) -> Transform {
+    pub fn parse_orientation(&self, orientation: &str) -> TransformAction {
         match orientation {
             "normal" => self.normal,
             "left-up" => self.left_up,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,18 +1,17 @@
-use std::fmt::Display;
-
+use crate::{app::ListenArgs, monitor};
 use anyhow::{anyhow, Result};
 use clap::builder::PossibleValue;
 use log::{info, warn};
 use niri_ipc::{socket::Socket, Transform};
 use serde::{Deserialize, Serialize};
-
-use crate::{app::ListenArgs, monitor};
+use std::fmt::Display;
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransformAction {
     Set(Transform),
     KeepPrevious,
 }
+
 impl clap::ValueEnum for TransformAction {
     fn value_variants<'a>() -> &'a [Self] {
         // sadly, clap doesnt nicely support nested ValueEnum, exactly because of this
@@ -38,6 +37,7 @@ impl clap::ValueEnum for TransformAction {
         }
     }
 }
+
 /// Maps the accelerometer transforms (normal,left-up,bottom-up,right-up) to Niri's transforms.
 ///
 /// In some devices the accelerometer orientation doesn't match the display orientation.
@@ -55,22 +55,23 @@ pub struct TransformMapping {
     pub bottom_up: TransformAction,
     pub right_up: TransformAction,
 }
+
 impl TransformMapping {
     /// Creates a mapping using a 4-transforms array.
     pub fn from_transform_vec(transform: Option<Vec<TransformAction>>) -> Result<TransformMapping> {
         match transform {
             Some(vec) => {
-                if vec.len() != 4 {
-                    Err(anyhow!(
-                        "Couldn't create the TransformMapping using the provided Vector."
-                    ))
-                } else {
+                if vec.len() == 4 {
                     Ok(TransformMapping {
                         normal: vec[0],
                         left_up: vec[1],
                         bottom_up: vec[2],
                         right_up: vec[3],
                     })
+                } else {
+                    Err(anyhow!(
+                        "Couldn't create the TransformMapping using the provided Vector."
+                    ))
                 }
             }
             None => Ok(TransformMapping {
@@ -96,11 +97,10 @@ impl TransformMapping {
 
 impl Display for TransformMapping {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let string = match serde_json::to_string(self) {
-            Ok(s) => s,
-            Err(_) => return Err(std::fmt::Error),
+        let Ok(string) = serde_json::to_string(self) else {
+            return Err(std::fmt::Error);
         };
-        write!(f, "{}", string)
+        write!(f, "{string}")
     }
 }
 
@@ -120,10 +120,10 @@ pub struct State {
 impl State {
     /// Create the state from the command line arguments
     pub fn from_args(niri_socket: &mut Socket, args: &ListenArgs) -> Result<Self> {
-        let monitor = monitor::get_monitor(niri_socket, args.monitor.to_owned())?;
-        warn!("Using monitor {}.", monitor);
-        let transform = TransformMapping::from_transform_vec(args.transform.to_owned())?;
-        info!("Using transformation matrix {:?}.", transform);
+        let monitor = monitor::get_monitor(niri_socket, args.monitor.clone())?;
+        warn!("Using monitor {monitor}.");
+        let transform = TransformMapping::from_transform_vec(args.transform.clone())?;
+        info!("Using transformation matrix {transform:?}.");
 
         Ok(Self {
             lock_rotation: args.lock_rotation,


### PR DESCRIPTION
Closes: #11 

`keep` is very useful for disabling/skipping unwanted orientations, for example portrait.

This PR implements it as an additional --transform orientation

other changes:
- update rust edition to 2024
- resolve most clippy::pedantic lints
- remove `value_separator=','` which is broken/incompatible with num_args
- add short description of `--transform` in README, alongside example to disable portrait orientations